### PR TITLE
consider URLs in TIPP matching, check platform status

### DIFF
--- a/server/gokb/application.properties
+++ b/server/gokb/application.properties
@@ -1,7 +1,7 @@
 #Grails Metadata file
-#Wed Aug 16 19:13:08 CEST 2017
-app.buildDate=Aug 16, 2017
-app.buildNumber=3403
+#Wed Aug 23 17:31:43 CEST 2017
+app.buildDate=Aug 23, 2017
+app.buildNumber=3430
 app.buildProfile=development
 app.grails.version=2.5.5
 app.name=gokb

--- a/server/gokb/application.properties
+++ b/server/gokb/application.properties
@@ -1,7 +1,7 @@
 #Grails Metadata file
-#Mon Aug 07 10:56:19 CEST 2017
-app.buildDate=Aug 07, 2017
-app.buildNumber=3391
+#Wed Aug 16 19:13:08 CEST 2017
+app.buildDate=Aug 16, 2017
+app.buildNumber=3403
 app.buildProfile=development
 app.grails.version=2.5.5
 app.name=gokb

--- a/server/gokb/grails-app/conf/Config.groovy
+++ b/server/gokb/grails-app/conf/Config.groovy
@@ -1323,7 +1323,7 @@ globalSearchTemplates = [
         [heading:'Status', property:'status?.value'],
         [heading:'Raised By', property:'raisedBy?.username'],
         [heading:'Allocated To', property:'allocatedTo?.username'],
-        [heading:'Timestamp', property:'dateCreated'],
+        [heading:'Timestamp', property:'dateCreated', sort:'dateCreated'],
         [heading:'Project', property:'refineProject?.name', link:[controller:'resource', action:'show', id:'x.r.refineProject?.class?.name+\':\'+x.r.refineProject?.id']],
       ]
     ]

--- a/server/gokb/grails-app/conf/Config.groovy
+++ b/server/gokb/grails-app/conf/Config.groovy
@@ -552,6 +552,8 @@ log4j = {
             'grails.app.jobs',
             'com.k_int',
             'org.gokb.cred.RefdataCategory',
+            'org.gokb.cred.TitleInstancePackagePlatform',
+            'org.gokb.cred.Platform',
             'org.gokb.IntegrationController',
             'com.k_int.apis',
             'com.k_int.asset.pipeline.groovy',
@@ -1232,10 +1234,19 @@ globalSearchTemplates = [
           placeholder:'Platform',
           contextTree:['ctxtp':'qry', 'comparator' : 'eq', 'prop':'hostPlatform']
         ],
+        [
+          type:'lookup',
+          baseClass:'org.gokb.cred.RefdataValue',
+          filter1:'KBComponent.Status',
+          prompt:'Status',
+          qparam:'qp_status',
+          placeholder:'Name or title of item',
+          contextTree:['ctxtp':'qry', 'comparator' : 'eq', 'prop':'status'],
+          // II: Default not yet implemented
+          default:[ type:'query', query:'select r from RefdataValue where r.value=:v and r.owner.description=:o', params:['Current','KBComponent.Status'] ]
+        ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
       ],
       qbeResults:[
         [heading:'TIPP Persistent Id', property:'persistentId', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'] ],

--- a/server/gokb/grails-app/controllers/org/gokb/ApiController.groovy
+++ b/server/gokb/grails-app/controllers/org/gokb/ApiController.groovy
@@ -90,10 +90,10 @@ class ApiController {
     else {
       def gokbVersion = request.getHeader("GOKb-version")
       def serv_url = grailsApplication.config.extensionDownloadUrl ?: 'http://gokb.kuali.org'
-      
+
       if (gokbVersion != 'development') {
         if (!gokbVersion || TextUtils.versionCompare(gokbVersion, grailsApplication.config.refine_min_version) < 0) {
-          apiReturn([errorType : "versionError"], "The refine extension you are using is not compaitble with this instance of the service.",
+          apiReturn([errorType : "versionError"], "The refine extension you are using is not compatible with this instance of the service.",
           "error")
           
           return false

--- a/server/gokb/grails-app/controllers/org/gokb/IntegrationController.groovy
+++ b/server/gokb/grails-app/controllers/org/gokb/IntegrationController.groovy
@@ -742,7 +742,7 @@ class IntegrationController {
         def existing_tipps = []
 
         if ( the_pkg.tipps?.size() > 0 ) {
-          existing_tipps = the_pkg.tipps
+          existing_tipps = the_pkg.tipps.collect { it.id }
           log.debug("Matched package has ${the_pkg.tipps.size()} TIPPs")
         }
 
@@ -844,9 +844,9 @@ class IntegrationController {
 
               def upserted_tipp = TitleInstancePackagePlatform.upsertDTO(tipp)
 
-              if ( existing_tipps.size() > 0 && upserted_tipp && existing_tipps.contains(upserted_tipp) ) {
+              if ( existing_tipps.size() > 0 && upserted_tipp && existing_tipps.contains(upserted_tipp.id) ) {
                 log.debug("Existing TIPP matched!")
-                tipps_to_delete.remove(upserted_tipp)
+                tipps_to_delete.remove(upserted_tipp.id)
               }
             }
           }
@@ -856,14 +856,16 @@ class IntegrationController {
 
 
             tipps_to_delete.each { ttd ->
-
-              if ( ttd.isCurrent() ) {
+              
+              def to_retire = TitleInstancePackagePlatform.get(ttd)
+              
+              if ( to_retire.isCurrent() ) {
                 
-                ttd.retire()
-                ttd.save(failOnError: true)
+                to_retire.retire()
+                to_retire.save(failOnError: true)
 
 //                 ReviewRequest.raise(
-//                     ttd,
+//                     to_retire,
 //                     "TIPP retired.",
 //                     "An update to this package did not contain this TIPP.",
 //                     user

--- a/server/gokb/grails-app/controllers/org/gokb/IntegrationController.groovy
+++ b/server/gokb/grails-app/controllers/org/gokb/IntegrationController.groovy
@@ -116,7 +116,7 @@ class IntegrationController {
             if ( located_entries?.size() == 0 ) {
               log.debug("No match on normalised name ${normname}.. Trying variant names");
               def variant_normname = GOKbTextUtils.normaliseString( name )
-              located_entries = Org.executeQuery("select distinct o from Org as o join o.variantNames as v where v.normVariantName = ?",[variant_normname]);
+              located_entries = Org.executeQuery("select distinct o from Org as o join o.variantNames as v where v.normVariantName = ? and o.status.value <> 'Deleted'",[variant_normname]);
 
               if ( located_entries?.size() == 0 ) {
 
@@ -265,7 +265,7 @@ class IntegrationController {
           if ( located_or_new_org == null && org_by_name.size() == 0 ) {
 
             def variant_normname = GOKbTextUtils.normaliseString( orgName )
-            def candidate_orgs = Org.executeQuery("select distinct o from Org as o join o.variantNames as v where v.normVariantName = ?",[variant_normname]);
+            def candidate_orgs = Org.executeQuery("select distinct o from Org as o join o.variantNames as v where v.normVariantName = ? and o.status.value <> 'Deleted'",[variant_normname]);
 
             if(candidate_orgs.size() == 1){
               located_or_new_org = candidate_orgs[0]
@@ -859,7 +859,7 @@ class IntegrationController {
 
               if ( ttd.isCurrent() ) {
                 
-                ttd.deleteSoft()
+                ttd.retire()
                 ttd.save(failOnError: true)
 
 //                 ReviewRequest.raise(
@@ -880,7 +880,7 @@ class IntegrationController {
               )
             }
           }
-          log.debug("Found ${num_deleted_tipps} TIPPS to delete from the matched package!")
+          log.debug("Found ${num_deleted_tipps} TIPPS to retire from the matched package!")
 
           log.debug("Elapsed tipp processing time: ${System.currentTimeMillis()-tipp_upsert_start_time} for ${tippctr} records")
         }
@@ -1227,9 +1227,9 @@ class IntegrationController {
         Org publisher = Org.findByNormname(norm_pub_name)
 
 
-        if(!publisher){
+        if(!publisher || publisher.status.value == 'Deleted'){
           def variant_normname = GOKbTextUtils.normaliseString(pub_to_add.name)
-          def candidate_orgs = Org.executeQuery("select distinct o from Org as o join o.variantNames as v where v.normVariantName = ?",[variant_normname]);
+          def candidate_orgs = Org.executeQuery("select distinct o from Org as o join o.variantNames as v where v.normVariantName = ? and o.status.value <> 'Deleted'",[variant_normname]);
 
           if(candidate_orgs.size() == 1){
             publisher = candidate_orgs[0]

--- a/server/gokb/grails-app/domain/org/gokb/cred/Package.groovy
+++ b/server/gokb/grails-app/domain/org/gokb/cred/Package.groovy
@@ -541,9 +541,9 @@ select tipp.id,
     if ( packageHeaderDTO.nominalPlatform ) {
       def platformDTO = [:];
 
-      if (packageHeaderDTO.nominalPlatform instanceof String){
+      if (packageHeaderDTO.nominalPlatform instanceof String && packageHeaderDTO.nominalPlatform.trim().size() > 0){
         platformDTO['name'] = packageHeaderDTO.nominalPlatform
-      }else if(packageHeaderDTO.nominalPlatform.name){
+      }else if(packageHeaderDTO.nominalPlatform.name && packageHeaderDTO.nominalPlatform.name.trim().size() > 0){
         platformDTO = packageHeaderDTO.nominalPlatform
       }
 

--- a/server/gokb/grails-app/domain/org/gokb/cred/Platform.groovy
+++ b/server/gokb/grails-app/domain/org/gokb/cred/Platform.groovy
@@ -162,22 +162,24 @@ class Platform extends KBComponent {
     def skip = false;
     def status_current = RefdataCategory.lookupOrCreate('KBComponent.Status','Current')
     
-    try {
-      log.debug("checking if platform name is an URL..")
-      
-      def url_as_name = new URL(platformDTO.name)
-      
-      if(url_as_name.getProtocol()){ 
-        if(!platformDTO.primaryUrl || platformDTO.primaryUrl.trim.size() == 0){
-          log.debug("identified URL as platform name")
-          platformDTO.primaryUrl = platformDTO.name
-        }
+    if(platformDTO.name.startsWith("http")){
+      try {
+        log.debug("checking if platform name is an URL..")
         
-        platformDTO.name = url_as_name.getHost()
-        log.debug("New platform name is ${platformDTO.name}.")
+        def url_as_name = new URL(platformDTO.name)
+        
+        if(url_as_name.getProtocol()){ 
+          if(!platformDTO.primaryUrl || platformDTO.primaryUrl.trim.size() == 0){
+            log.debug("identified URL as platform name")
+            platformDTO.primaryUrl = platformDTO.name
+          }
+          
+          platformDTO.name = url_as_name.getHost()
+          log.debug("New platform name is ${platformDTO.name}.")
+        }
+      } catch( MalformedURLException ){
+        log.debug("Platform name is no valid URL")
       }
-    } catch( MalformedURLException ){
-      log.debug("Platform name is no URL")
     }
     
     def name_candidates = Platform.executeQuery("from Platform where name = ? and status = ?", [platformDTO.name, status_current]);

--- a/server/gokb/grails-app/domain/org/gokb/cred/TitleInstancePackagePlatform.groovy
+++ b/server/gokb/grails-app/domain/org/gokb/cred/TitleInstancePackagePlatform.groovy
@@ -180,7 +180,7 @@ class TitleInstancePackagePlatform extends KBComponent {
 
     if ( pkg && plt && ti ) {
       log.debug("See if we already have a tipp");
-      def tipps = TitleInstance.executeQuery('select tipp.id from TitleInstancePackagePlatform as tipp, Combo as pkg_combo, Combo as title_combo, Combo as platform_combo  '+
+      def tipps = TitleInstance.executeQuery('select tipp from TitleInstancePackagePlatform as tipp, Combo as pkg_combo, Combo as title_combo, Combo as platform_combo  '+
                                            'where pkg_combo.toComponent=tipp and pkg_combo.fromComponent=?'+
                                            'and platform_combo.toComponent=tipp and platform_combo.fromComponent = ?'+
                                            'and title_combo.toComponent=tipp and title_combo.fromComponent = ?',
@@ -189,19 +189,32 @@ class TitleInstancePackagePlatform extends KBComponent {
       switch ( tipps.size() ) {
         case 1:
           log.debug("found");
-          tipp = TitleInstancePackagePlatform.get(tipps[0])
+
+          if( tipps[0].url && tipp_dto.url && tipps[0].url == tipp_dto.url ){
+            tipp = tipps[0]
+          }
           break;
         case 0:
           log.debug("not found");
-          tipp=new TitleInstancePackagePlatform()
-          tipp.pkg = pkg;
-          tipp.title = ti;
-          tipp.hostPlatform = plt;
           
           break;
         default:
-          log.error("Multiple matches found for tipp..");
+          tipps.each {
+            if ( tipp_dto.url && it.url == tipp_dto.url ){
+              if(tipp){
+                log.warn("found multiple TIPPs with the same URL!")
+              }
+              tipp = it
+            }
+          }
           break;
+      }
+
+      if ( !tipp ) {
+        tipp=new TitleInstancePackagePlatform()
+        tipp.pkg = pkg;
+        tipp.title = ti;
+        tipp.hostPlatform = plt;
       }
 
       if ( tipp ) {

--- a/server/gokb/grails-app/services/org/gokb/TitleLookupService.groovy
+++ b/server/gokb/grails-app/services/org/gokb/TitleLookupService.groovy
@@ -431,6 +431,7 @@ class TitleLookupService {
           case 1 :
             log.debug("One match for all identifiers")
             the_title = all_matched[0]
+
             if(!the_title.name.equals(metadata.title)){
               the_title.addVariantTitle(metadata.title)
             }
@@ -538,7 +539,7 @@ class TitleLookupService {
       log.debug("Add publisher \"${publisher_name}\"")
       Org publisher = componentLookupService.lookupComponent(publisher_name)
       
-      if (publisher == null) {
+      if ( !publisher ) {
         // Lookup using norm name.
         def norm_pub_name = Org.generateNormname(publisher_name);
         
@@ -546,9 +547,9 @@ class TitleLookupService {
         publisher = Org.findByNormname(norm_pub_name)
       }      
 
-      if ( publisher == null ) {
+      if ( !publisher || publisher.status.value == 'Deleted') {
         def variant_normname = GOKbTextUtils.normaliseString(publisher_name)
-        def candidate_orgs = Org.executeQuery("select distinct o from Org as o join o.variantNames as v where v.normVariantName = ?",[variant_normname]);
+        def candidate_orgs = Org.executeQuery("select distinct o from Org as o join o.variantNames as v where v.normVariantName = ? and o.status.value <> 'Deleted'",[variant_normname]);
         if ( candidate_orgs.size() == 1 ) {
           publisher = candidate_orgs[0]
         }

--- a/server/gokb/grails-app/views/apptemplates/_package.gsp
+++ b/server/gokb/grails-app/views/apptemplates/_package.gsp
@@ -95,7 +95,7 @@
 
       <div class="tab-pane" id="titledetails">
         <g:link class="display-inline" controller="search" action="index"
-          params="[qbe:'g:3tipps', qp_pkg_id:d.id, hide:['qp_pkg_id', 'qp_cp', 'qp_pkg', 'qp_pub_id', 'qp_plat']]"
+          params="[qbe:'g:3tipps', qp_pkg_id:d.id, hide:['qp_pkg_id', 'qp_cp', 'qp_pkg', 'qp_pub_id', 'qp_plat', 'qp_status']]"
           id="">Titles in this package</g:link>
 
         <g:if test="${ editable }">

--- a/server/gokb/grails-app/views/group/index.gsp
+++ b/server/gokb/grails-app/views/group/index.gsp
@@ -23,7 +23,12 @@
           <th>Status</th>
           <th>List verified by</th>
           <th>List verified date</th>
-          <th>Last Modified</th>
+          <th>
+            <g:link params="${params+[pkg_sort:'lastUpdated',pkg_sort_order:('desc'== params.pkg_sort_order?'asc':'desc')]}">
+              Last Modified
+              <i class="glyphicon glyphicon-sort"></i>
+            </g:link>
+          </th>
           <th>Scope</th>
           <th>ListStatus</th>
           <th>Number of Titles (TIPPs)</th>

--- a/server/gokb/grails-app/views/workflow/platformReplacement.gsp
+++ b/server/gokb/grails-app/views/workflow/platformReplacement.gsp
@@ -37,7 +37,7 @@
 					<dd>
 						<div class="input-group">
 							<g:simpleReferenceTypedown class="form-control"
-								name="newplatform" baseClass="org.gokb.cred.Platform" />
+								name="newplatform" baseClass="org.gokb.cred.Platform" status="Current"/>
 							<div class="input-group-btn">
 								<button type="submit" class="btn btn-default btn-sm">Update</button>
 							</div>


### PR DESCRIPTION
- Use Package identifiers & variantNames for matching, if name matching does not yield a result
- Make sure matched Platforms are not 'Deleted'
- URLs should be considered when matching TIPPs, because there may be TitleInstances with multiple TIPPs on the same Platform (e.g. multi-series publications). As a result, URL changes will now create a new TIPP. Since existing TIPPs missing in updates to a Package are now automatically retired, this will not erroneously inflate the number of its current TIPPs.
