### PR TITLE
platformReplacement selection, status filters

### DIFF
--- a/server/gokb/application.properties
+++ b/server/gokb/application.properties
@@ -1,7 +1,7 @@
 #Grails Metadata file
-#Wed Aug 23 17:31:43 CEST 2017
-app.buildDate=Aug 23, 2017
-app.buildNumber=3430
+#Mon Aug 28 17:48:42 CEST 2017
+app.buildDate=Aug 28, 2017
+app.buildNumber=3439
 app.buildProfile=development
 app.grails.version=2.5.5
 app.name=gokb

--- a/server/gokb/application.properties
+++ b/server/gokb/application.properties
@@ -1,7 +1,7 @@
 #Grails Metadata file
-#Mon Aug 28 17:48:42 CEST 2017
-app.buildDate=Aug 28, 2017
-app.buildNumber=3439
+#Tue Aug 29 15:31:04 CEST 2017
+app.buildDate=Aug 29, 2017
+app.buildNumber=3441
 app.buildProfile=development
 app.grails.version=2.5.5
 app.name=gokb

--- a/server/gokb/application.properties
+++ b/server/gokb/application.properties
@@ -1,7 +1,7 @@
 #Grails Metadata file
-#Tue Aug 29 15:31:04 CEST 2017
-app.buildDate=Aug 29, 2017
-app.buildNumber=3441
+#Wed Aug 30 13:48:03 CEST 2017
+app.buildDate=Aug 30, 2017
+app.buildNumber=3442
 app.buildProfile=development
 app.grails.version=2.5.5
 app.name=gokb

--- a/server/gokb/grails-app/conf/Config.groovy
+++ b/server/gokb/grails-app/conf/Config.groovy
@@ -1238,6 +1238,12 @@ globalSearchTemplates = [
           contextTree:['ctxtp':'qry', 'comparator' : 'eq', 'prop':'pkg']
         ],
         [
+          prompt:'Platform ID',
+          qparam:'qp_plat_id',
+          placeholder:'Platform ID',
+          contextTree:['ctxtp' : 'qry', 'comparator' : 'eq', 'prop' : 'hostPlatform.id', 'type' : 'java.lang.Long']
+        ],
+        [
           type:'lookup',
           baseClass:'org.gokb.cred.Platform',
           prompt:'Platform',

--- a/server/gokb/grails-app/conf/Config.groovy
+++ b/server/gokb/grails-app/conf/Config.groovy
@@ -964,8 +964,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Type', property:'class.simpleName'],
@@ -1006,8 +1006,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Provider', property:'provider?.name'],
@@ -1037,8 +1037,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Name', property:'name',sort:'name', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'] ],
@@ -1060,10 +1060,21 @@ globalSearchTemplates = [
           placeholder:'Name or title of item',
           contextTree:['ctxtp':'qry', 'comparator' : 'ilike', 'prop':'name']
         ],
+        [
+          type:'lookup',
+          baseClass:'org.gokb.cred.RefdataValue',
+          filter1:'KBComponent.Status',
+          prompt:'Status',
+          qparam:'qp_status',
+          placeholder:'Component Status',
+          contextTree:['ctxtp':'qry', 'comparator' : 'eq', 'prop':'status'],
+          // II: Default not yet implemented
+          default:[ type:'query', query:'select r from RefdataValue where r.value=:v and r.owner.description=:o', params:['Current','KBComponent.Status'] ]
+        ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Name/Title', property:'name', sort:'name',link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'] ],
@@ -1134,8 +1145,8 @@ globalSearchTemplates = [
         // ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'ID', property:'id', link:[controller:'resource',action:'show',id:'x.r?.class?.name+\':\'+x.r?.id'],sort:'name' ],
@@ -1240,13 +1251,15 @@ globalSearchTemplates = [
           filter1:'KBComponent.Status',
           prompt:'Status',
           qparam:'qp_status',
-          placeholder:'Name or title of item',
+          placeholder:'Status',
           contextTree:['ctxtp':'qry', 'comparator' : 'eq', 'prop':'status'],
           // II: Default not yet implemented
           default:[ type:'query', query:'select r from RefdataValue where r.value=:v and r.owner.description=:o', params:['Current','KBComponent.Status'] ]
         ],
       ],
       qbeGlobals:[
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'TIPP Persistent Id', property:'persistentId', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'] ],
@@ -1325,8 +1338,6 @@ globalSearchTemplates = [
         ]
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
       ],
       qbeResults:[
         [heading:'Cause', property:'descriptionOfCause', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id']],
@@ -1353,8 +1364,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Name/Title', property:'name',sort:'name', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'] ],
@@ -1376,8 +1387,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Name/Title', property:'name',sort:'name', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'] ],
@@ -1421,8 +1432,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Name/Title', property:'name', sort:'name', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'] ],
@@ -1465,8 +1476,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted',
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'ID', property:'id', sort:'id', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'] ],
@@ -1680,8 +1691,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted', 
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Title', property:'name', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'],sort:'name' ],
@@ -1714,8 +1725,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted', 
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Title', property:'name', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'],sort:'name' ],
@@ -1739,8 +1750,8 @@ globalSearchTemplates = [
         ],
       ],
       qbeGlobals:[
-        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Deleted', 'negate' : true, 'prompt':'Hide Deleted', 
-         'qparam':'qp_showDeleted', 'default':'on']
+        ['ctxtp':'filter', 'prop':'status.value', 'comparator' : 'eq', 'value':'Current', 'negate' : false, 'prompt':'Only Current',
+         'qparam':'qp_onlyCurrent', 'default':'off']
       ],
       qbeResults:[
         [heading:'Title', property:'name', link:[controller:'resource',action:'show',id:'x.r.class.name+\':\'+x.r.id'],sort:'name' ],

--- a/server/gokb/grails-app/controllers/org/gokb/IntegrationController.groovy
+++ b/server/gokb/grails-app/controllers/org/gokb/IntegrationController.groovy
@@ -1173,8 +1173,9 @@ class IntegrationController {
             }
           }
         }
-        if(titleObj.type == 'Book' || titleObj.type == 'Monograph'){
-
+        if( title.class.name == "org.gokb.cred.BookInstance" && (titleObj.type == 'Book' || titleObj.type == 'Monograph') ){
+          
+          log.debug("Adding Monograph fields for ${title.class.name}: ${title}")
           def mg_change = addMonographFields(title, titleObj, sdf)
 
           // TODO: Here we will have to add authors and editors, like addPerson() in TSVIngestionService

--- a/server/gokb/grails-app/domain/org/gokb/cred/Org.groovy
+++ b/server/gokb/grails-app/domain/org/gokb/cred/Org.groovy
@@ -84,7 +84,9 @@ class Org extends KBComponent {
 
     if ( ql ) {
       ql.each { t ->
-        result.add([id:"${t.class.name}:${t.id}",text:"${t.name}"])
+        if( !params.filter1 || t.status.value == params.filter1 ){
+          result.add([id:"${t.class.name}:${t.id}",text:"${t.name}"])
+        }
       }
     }
 

--- a/server/gokb/grails-app/domain/org/gokb/cred/Platform.groovy
+++ b/server/gokb/grails-app/domain/org/gokb/cred/Platform.groovy
@@ -119,7 +119,7 @@ class Platform extends KBComponent {
 
     if ( ql ) { 
       ql.each { t ->
-        if( !params.status || t.status.value != params.status ){
+        if( !params.filter1 || t.status.value == params.filter1 ){
           result.add([id:"${t.class.name}:${t.id}",text:"${t.name}"])
         }
       }   

--- a/server/gokb/grails-app/domain/org/gokb/cred/Platform.groovy
+++ b/server/gokb/grails-app/domain/org/gokb/cred/Platform.groovy
@@ -250,8 +250,11 @@ class Platform extends KBComponent {
         // skip = true
         def current_platforms = url_candidates.findAll { it.status == status_current }
 
-        if(current_platforms.size() > 0){
+        if(current_platforms.size() == 1){
           result = current_platforms[0]
+        }else{
+          log.debug("Could not decide on a Platform, skipping..")
+          skip = true;
         }
       }
     }

--- a/server/gokb/grails-app/views/apptemplates/_package.gsp
+++ b/server/gokb/grails-app/views/apptemplates/_package.gsp
@@ -95,7 +95,7 @@
 
       <div class="tab-pane" id="titledetails">
         <g:link class="display-inline" controller="search" action="index"
-          params="[qbe:'g:3tipps', qp_pkg_id:d.id, hide:['qp_pkg_id', 'qp_cp', 'qp_pkg', 'qp_pub_id', 'qp_plat', 'qp_status']]"
+          params="[qbe:'g:3tipps', qp_pkg_id:d.id, hide:['qp_pkg_id', 'qp_cp', 'qp_pkg', 'qp_pub_id', 'qp_plat']]"
           id="">Titles in this package</g:link>
 
         <g:if test="${ editable }">
@@ -130,6 +130,8 @@
                                 model="${[d:d, property:'ids', cols:[
                   [expr:'toComponent.namespace.value', colhead:'Namespace'],
                   [expr:'toComponent.value', colhead:'ID', action:'link']]]}" />
+                  
+        <g:render template="addIdentifier" contextPath="../apptemplates" model="${[d:d, hash:'#identifiers']}"/>
       </div>
 
       <div class="tab-pane" id="ds">

--- a/server/gokb/grails-app/views/apptemplates/_package.gsp
+++ b/server/gokb/grails-app/views/apptemplates/_package.gsp
@@ -23,14 +23,14 @@
     <dd>
       <g:manyToOneReferenceTypedown owner="${d}" field="source" baseClass="org.gokb.cred.Source">${d.source?.name}</g:manyToOneReferenceTypedown>
     </dd>
-    
-    <dt>
-      <g:annotatedLabel owner="${d}" property="status">Status</g:annotatedLabel>
-    </dt>
-    <dd>
-      <g:xEditableRefData owner="${d}" field="status"
-        config="KBComponent.Status" />
-    </dd>
+    <g:if test="${d.status}">
+      <dt>
+        <g:annotatedLabel owner="${d}" property="status">Status</g:annotatedLabel>
+      </dt>
+      <dd>
+        ${d.status.value}
+      </dd>
+    </g:if>
 
     <g:if test="${d.lastProject}">
       <dt>

--- a/server/gokb/grails-app/views/apptemplates/_package.gsp
+++ b/server/gokb/grails-app/views/apptemplates/_package.gsp
@@ -28,7 +28,8 @@
       <g:annotatedLabel owner="${d}" property="status">Status</g:annotatedLabel>
     </dt>
     <dd>
-      ${d.status.value}
+      <g:xEditableRefData owner="${d}" field="status"
+        config="KBComponent.Status" />
     </dd>
 
     <g:if test="${d.lastProject}">

--- a/server/gokb/grails-app/views/apptemplates/_platform.gsp
+++ b/server/gokb/grails-app/views/apptemplates/_platform.gsp
@@ -39,7 +39,7 @@
 
   <ul id="tabs" class="nav nav-tabs">
     <li class="active"><a href="#platformdetails" data-toggle="tab">Platform Details</a></li>
-    <li><a href="#titledetails" data-toggle="tab">Hosted TIPPs <span class="badge badge-warning"> ${d.hostedTipps.size()}</span> </a></li>
+    <li><a href="#titledetails" data-toggle="tab">Hosted TIPPs <span class="badge badge-warning"> ${d.hostedTipps?.size()}</span> </a></li>
     <li><a href="#altnames" data-toggle="tab">Alternate Names <span class="badge badge-warning"> ${d.variantNames?.size()}</span> </a></li>
     <li><a href="#ds" data-toggle="tab">Decision Support</a></li>
   </ul>
@@ -95,10 +95,9 @@
 
       </dl>
     </div>
-    
     <div class="tab-pane" id="titledetails">
       <g:link class="display-inline" controller="search" action="index"
-        params="[qbe:'g:3tipps', qp_plat_id:d.id, hide:['qp_pkg_id', 'qp_cp', 'qp_pkg', 'qp_pub_id', 'qp_plat', 'qp_plat_id']]"
+        params="[qbe:'g:3tipps', qp_plat_id:d.id, hide:['qp_cp', 'qp_pkg', 'qp_pub_id', 'qp_plat', 'qp_plat_id']]"
         id="">TIPPs on this Platform</g:link>
     </div>
         

--- a/server/gokb/grails-app/views/apptemplates/_platform.gsp
+++ b/server/gokb/grails-app/views/apptemplates/_platform.gsp
@@ -39,6 +39,7 @@
 
   <ul id="tabs" class="nav nav-tabs">
     <li class="active"><a href="#platformdetails" data-toggle="tab">Platform Details</a></li>
+    <li><a href="#titledetails" data-toggle="tab">Hosted TIPPs <span class="badge badge-warning"> ${d.hostedTipps.size()}</span> </a></li>
     <li><a href="#altnames" data-toggle="tab">Alternate Names <span class="badge badge-warning"> ${d.variantNames?.size()}</span> </a></li>
     <li><a href="#ds" data-toggle="tab">Decision Support</a></li>
   </ul>
@@ -58,7 +59,7 @@
               &nbsp; <a href="${d.primaryUrl}" target="new">Follow Link</a>
             </g:if>
             <g:else>
-              &nbsp; <span class="badge badge-warning">Unknown URL format</span>
+              &nbsp; <span class="badge badge-warning">!Unknown URL format!</span>
             </g:else>
           </g:if>
         </dd>
@@ -94,6 +95,13 @@
 
       </dl>
     </div>
+    
+    <div class="tab-pane" id="titledetails">
+      <g:link class="display-inline" controller="search" action="index"
+        params="[qbe:'g:3tipps', qp_plat_id:d.id, hide:['qp_pkg_id', 'qp_cp', 'qp_pkg', 'qp_pub_id', 'qp_plat', 'qp_plat_id']]"
+        id="">TIPPs on this Platform</g:link>
+    </div>
+        
     <g:render template="showVariantnames" contextPath="../tabTemplates"
       model="${[d:displayobj, showActions:true]}" />
             

--- a/server/gokb/grails-app/views/globalSearch/index.gsp
+++ b/server/gokb/grails-app/views/globalSearch/index.gsp
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <%
   def addFacet = { params, facet, val ->
@@ -111,14 +112,16 @@
                <tr>
                  <th>Component Name</th>
                  <th>Component Type</th>
+                 <th style="width:10%">Status</th>
                </tr>
              </thead>
              <tbody>
                <g:each in="${hits}" var="hit">
+                <g:set var="hitInst" value="${org.gokb.cred.KBComponent.get(hit.id.split(':')[1].toLong())}" />
                  <tr>
-                   <td> <g:link controller="resource" action="show" id="${hit.id}">${hit.source.name}</g:link></td>
+                   <td> <g:if test="${hitInst}"><g:link controller="resource" action="show" id="${hit.id}">${hit.source.name ?: "- Not Set -"}</g:link></g:if><g:else>${hit.source.name ?: "- Not Set -"}</g:else></td>
                    <td> ${hit.source.componentType} </td>
-                   <td> ${hit.source}</td>
+                   <td> ${hitInst?.status?.value ?: 'Unknown'}</td>
                  </tr>
                </g:each>
              </tbody>

--- a/server/gokb/grails-app/views/globalSearch/index.gsp
+++ b/server/gokb/grails-app/views/globalSearch/index.gsp
@@ -118,6 +118,7 @@
                  <tr>
                    <td> <g:link controller="resource" action="show" id="${hit.id}">${hit.source.name}</g:link></td>
                    <td> ${hit.source.componentType} </td>
+                   <td> ${hit.source}</td>
                  </tr>
                </g:each>
              </tbody>

--- a/server/gokb/grails-app/views/resource/show.gsp
+++ b/server/gokb/grails-app/views/resource/show.gsp
@@ -3,8 +3,13 @@
 <head>
 <meta name="layout" content="sb-admin" />
 <title>GOKb: ${displayobj?.getNiceName() ?: 'Component'} 
+<g:if test="${displayobj}">
 &lt;${ displayobj?.isEditable() ? 'Editable' : 'Read Only' }&gt; 
 &lt;${ displayobj?.isCreatable() ? 'Creatable' : 'Not Creatable' }&gt;
+</g:if>
+<g:else>
+&lt;Not found&gt;
+</g:else>
 </title>
 </head>
 <body>
@@ -23,26 +28,27 @@
         </g:else>
       </span>
     </div>
+    <g:if test="${displayobj}">
+      <ul class="nav navbar-nav navbar-right">
+        <g:if test="${d instanceof org.gokb.cred.KBComponent}">
+          <li><a onClick="javascript:toggleWatch('${displayobj.class.name}:${displayobj.id}')"
+                id="watchToggleLink"
+                title="${user_watching ? 'You are watching this item' : 'You are not watching this item'}"
+                  ><i id="watchIcon" class="glyphicon ${user_watching ? 'glyphicon-eye-open' : 'glyphicon-eye-close'}"></i> <span id="watchCounter" class="badge badge-warning"> ${num_watch}</span></a></li>
+        </g:if>
+        <li><a data-toggle="modal" data-cache="false"
+              title="Show History"
+              data-remote='<g:createLink controller="fwk" action="history" oid="${displayobj.class.name}:${displayobj.id}"/>'
+              data-target="#modal"><i class="glyphicon glyphicon-time"></i></a></li>
 
-    <ul class="nav navbar-nav navbar-right">
-      <g:if test="${d instanceof org.gokb.cred.KBComponent}">
-        <li><a onClick="javascript:toggleWatch('${displayobj.class.name}:${displayobj.id}')"
-               id="watchToggleLink"
-               title="${user_watching ? 'You are watching this item' : 'You are not watching this item'}"
-                ><i id="watchIcon" class="glyphicon ${user_watching ? 'glyphicon-eye-open' : 'glyphicon-eye-close'}"></i> <span id="watchCounter" class="badge badge-warning"> ${num_watch}</span></a></li>
-      </g:if>
-      <li><a data-toggle="modal" data-cache="false"
-             title="Show History"
-             data-remote='<g:createLink controller="fwk" action="history" oid="${displayobj.class.name}:${displayobj.id}"/>'
-             data-target="#modal"><i class="glyphicon glyphicon-time"></i></a></li>
-
-      <li><a data-toggle="modal" data-cache="false"
-             title="Show Notes"
-             data-remote='<g:createLink controller="fwk" action="notes" id="${displayobj.class.name}:${displayobj.id}"/>'
-             data-target="#modal"><i class="glyphicon glyphicon-comment"></i>
-              <span class="badge badge-warning"> ${num_notes}</span>
-          </a></li>
-    </ul>
+        <li><a data-toggle="modal" data-cache="false"
+              title="Show Notes"
+              data-remote='<g:createLink controller="fwk" action="notes" id="${displayobj.class.name}:${displayobj.id}"/>'
+              data-target="#modal"><i class="glyphicon glyphicon-comment"></i>
+                <span class="badge badge-warning"> ${num_notes}</span>
+            </a></li>
+      </ul>
+    </g:if>
   </div>
 </nav>
   <div id="mainarea" class="panel panel-default">

--- a/server/gokb/grails-app/views/workflow/platformReplacement.gsp
+++ b/server/gokb/grails-app/views/workflow/platformReplacement.gsp
@@ -37,7 +37,7 @@
 					<dd>
 						<div class="input-group">
 							<g:simpleReferenceTypedown class="form-control"
-								name="newplatform" baseClass="org.gokb.cred.Platform" status="Current"/>
+								name="newplatform" baseClass="org.gokb.cred.Platform" filter1="Current"/>
 							<div class="input-group-btn">
 								<button type="submit" class="btn btn-default btn-sm">Update</button>
 							</div>

--- a/server/gokb/grails-app/views/workflow/titleTransfer.gsp
+++ b/server/gokb/grails-app/views/workflow/titleTransfer.gsp
@@ -39,9 +39,9 @@
 						</table>
 					</div>
 					<div class="col-md-6">
-						<h3>Trasfer to:</h3>
+						<h3>Transfer to:</h3>
 						<label>New Publisher:</label>
-						<g:simpleReferenceTypedown class="form-control" name="title" baseClass="org.gokb.cred.Org" />
+						<g:simpleReferenceTypedown class="form-control" name="title" baseClass="org.gokb.cred.Org" filter1="Current"/>
 					</div>
 
 				</div>


### PR DESCRIPTION
- the suggestions for platforms in the platformReplacement view now only show 'Current' platforms
- same for orgs in titleTransfer
- changed the 'Hide Deleted' ('on' by default) filter in search templates to 'Only Current' ('off' by default)
- more components can now be filtered by their status when searching
- added option to add package identifiers
- fixed NPEs for newly staged components